### PR TITLE
Fix: Mongo Update queries, Date Dependancy overhaul

### DIFF
--- a/_config/config.sample.json
+++ b/_config/config.sample.json
@@ -4,6 +4,11 @@
     "security": {
         "default": "green"
     },
+    "icDate": {
+        "yearPrefix": "",
+        "yearAffix": "NT",
+        "yearDefault": 240
+    },
     "weather": {
         "enabled": false,
         "api_url": "http://weerlive.nl/api/json-data-10min.php?key=demo&locatie=Amsterdam"

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,4 @@
+import { App } from './lib/app';
+import { Server } from './lib/bin/server';
+
+export = (new Server()).create(new App());

--- a/lib/bin/models/time.ts
+++ b/lib/bin/models/time.ts
@@ -1,20 +1,37 @@
+import dayjs from "dayjs";
+import UTC from "dayjs/plugin/utc";
+import { getDayOfWeekName, getLocalizedDayNumber } from "../../modules/time/time.helper";
+
+dayjs.extend(UTC);
+
+import CONFIG from "../../../_config/config.json"
+const DEFAULT_DATES = CONFIG.icDate
+
 /**
  * @description Total time object.
  */
 export class IcDate {
-    ocEventStart: Date;
-    icEventStart: Date;
-    iStartDayOfWeek: 1 | 2 | 3 | 4 | 5 | 6 | 7;
-    iStartYear: number;
+    iYear: number
+    iYearBefore?: string
+    iYearAfter?: string
+    iDay: number
+    iMonth: number
+    iDayOfWeek: number
+    iDayName: string
+    iMonthName: string
 
-    iYear: number;
-    iYearBefore: string; // title BEFORE the year. For example <Anno> 1776
-    iYearAfter: string; // title AFTER the year. For example  1776 <A.D.>
-
-
-    iDay: number;
-    iMonth: number;
-    iDayOfWeek: number;
-    iDayName: string;
-    iMonthName: string;
+    constructor(inputDate) {
+        // this.ocEventStart = inputDate?.ocEventStart;
+        // this.icEventStart = inputDate?.icEventStart;
+        // this.iStartYear = inputDate?.iStartYear;
+        this.iYear = inputDate?.iYear || DEFAULT_DATES.yearDefault;
+        this.iYearBefore = inputDate?.iYearBefore || DEFAULT_DATES.yearPrefix;
+        this.iYearAfter = inputDate?.iYearAfter || DEFAULT_DATES.yearAffix;
+        this.iDay = inputDate?.iDay;
+        this.iMonth = inputDate?.iMonth;
+        this.iDayOfWeek = inputDate?.iDayOfWeek || getLocalizedDayNumber();
+        this.iDayName = inputDate?.iDayName || getDayOfWeekName();
+        this.iMonthName = inputDate?.iMonthName;
+    }
 }
+

--- a/lib/bin/server.ts
+++ b/lib/bin/server.ts
@@ -28,7 +28,7 @@ export class Server {
 
         // mongoose.Promise = global.Promise;
         try {
-            mongoose.connect(config.db, { useNewUrlParser: true }, (err) => {
+            mongoose.connect(config.db, { useNewUrlParser: true, useUnifiedTopology: true }, (err) => {
                 console.log('[&MONG] Database is connected');
             });
         } catch (error) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,0 @@
-import { App } from './app';
-import { Server } from './bin/server';
-
-export = (new Server()).create(new App());

--- a/lib/modules/fob/fob.controller.ts
+++ b/lib/modules/fob/fob.controller.ts
@@ -31,8 +31,14 @@ export class FobController {
     }
 
     public async updateFob(fob: any): Promise<void> {
+        const target = { _id: fob._id }
+        const changes = { ...fob }
+        delete changes._id
 
-        await Fob.updateOne({ _id: fob._id }, () => {
+        await Fob.findOneAndUpdate(target, changes, {
+            returnOriginal: false,
+            useFindAndModify: false
+        }, () => {
             FobController.emitOnFobChanges();
         });
     }

--- a/lib/modules/fob/fob.controller.ts
+++ b/lib/modules/fob/fob.controller.ts
@@ -1,6 +1,7 @@
 import Fob from '../../bin/models/fob';
 import { Server } from '../../bin/server';
 import { MOCKFOBS } from '../../bin/data/mockfobs';
+import { SOCKET_FOB_UPDATE } from '../../shared/constants.sockets';
 
 export class FobController {
 
@@ -15,7 +16,7 @@ export class FobController {
 
     private static async emitOnFobChanges(): Promise<void> {
         if (Server.socketio()) {
-            Server.socketio().sockets.emit('fobUpdate');
+            Server.socketio().sockets.emit(SOCKET_FOB_UPDATE);
         }
     }
 

--- a/lib/modules/mission/mission.controller.ts
+++ b/lib/modules/mission/mission.controller.ts
@@ -26,7 +26,18 @@ export class MissionController {
     }
 
     public async updateMission(mission: any): Promise<void> {
-        await Mission.updateOne( { _id: mission._id }, () => {
+        // await Mission.updateOne( { _id: mission._id }, () => {
+        //     MissionController.emitOnMissionChanges();
+        // });
+
+        const target = { _id: mission._id }
+        const changes = { ...mission }
+        delete changes._id
+
+        await Mission.findOneAndUpdate(target, changes, { 
+            returnOriginal: false,
+            useFindAndModify: false
+        }, () => {
             MissionController.emitOnMissionChanges();
         });
     }

--- a/lib/modules/mission/mission.controller.ts
+++ b/lib/modules/mission/mission.controller.ts
@@ -1,12 +1,11 @@
 import Mission from "../../bin/models/mission";
 import { Server } from '../../bin/server';
 import { MOCKMISSIONS } from '../../bin/data/mockmissions';
+import { SOCKET_MISSION_UPDATE } from "../../shared/constants.sockets";
 
 export class MissionController {
 
-    public static init(): void {
-
-    }
+    public static init(): void { }
 
     public createMission(mission: any): void {
         MissionController.createMissionInDB(mission);
@@ -43,9 +42,9 @@ export class MissionController {
     }
 
     private static async emitOnMissionChanges(): Promise<void> {
-        console.log('SOCKETUPDATE MISS event');
+        console.log('SocketUpdate: Mission Board updated');
         if(Server.socketio()) {
-            Server.socketio().sockets.emit('MissionUpdate');
+            Server.socketio().sockets.emit(SOCKET_MISSION_UPDATE);
         }
     }
 

--- a/lib/modules/security/security.controller.ts
+++ b/lib/modules/security/security.controller.ts
@@ -1,6 +1,7 @@
 const secData = require('../../bin/data/security.json');
 // import { SecurityModel } from '../../bin/models/securitylevels';
 const config = require('../../../_config/config.json');
+import { SOCKET_SECLVL_UPDATE } from '../../shared/constants.sockets';
 import { Server } from '../../bin/server';
 
 export class SecurityController {
@@ -44,7 +45,7 @@ export class SecurityController {
     }
 
     private static onSecurityChange(): void {
-        Server.socketio().sockets.emit('securityUpdate', this.currentSecLevel);
+        Server.socketio().sockets.emit(SOCKET_SECLVL_UPDATE, this.currentSecLevel);
     }
 
 }

--- a/lib/modules/time/OLD.time.controller.ts
+++ b/lib/modules/time/OLD.time.controller.ts
@@ -1,0 +1,107 @@
+// import moment = require('moment');
+// import { IcDate } from '../../bin/models/time';
+// import { Server } from '../../bin/server';
+// const CronJob = require('cron').CronJob;
+
+// export class TimeController {
+
+//     public static ingameDate: IcDate;
+
+//     public static init(): void {
+//         if (!this.ingameDate) {
+//             this.ingameDate = this.convertToIcDateObject({
+//                 ocEventStart: new Date(2022, 6, 9, 12), // at 12 o clock for timezone shenanigans.
+//                 icEventStart: new Date(2022, 6, 17, 12), // It's important that the current IC year is also the OC year.
+//                 icStartYear: 240,
+//                 icStartDayOfWeek: 5,
+//                 icYearAfter: 'NT'
+//             });
+//         }
+
+//         console.log('\x1b[36m[*CRON] TimeSocket cron set to trigger at Midnight.\x1b[0m');
+//         this.midnightUpdateCronJob.start();
+//     }
+
+//     private static midnightUpdateCronJob = new CronJob('0 0 * * *', function () {
+//         console.log(`[*CRON] trigger: \x1b[32m{midnightUpdateCronJob}\x1b[0m, ${new Date()}`);
+//         Server.socketio().sockets.emit('inGameDateUpdate');
+//     });
+
+//     private static convertToIcDateObject(input: any): IcDate {
+//         let convertedDate = new IcDate();
+//             convertedDate.ocEventStart = input.ocEventStart;
+//             convertedDate.icEventStart = input.icEventStart;
+//             convertedDate.iStartDayOfWeek = input.icStartDayOfWeek;
+//             convertedDate.iStartYear = input.icStartYear;
+//             convertedDate.iYearAfter = input.icYearAfter;
+//         return convertedDate;
+//     }
+
+//     public static getCurrentDate(): IcDate {
+//         if (this.ingameDate) {
+//             const ActualIcDate = this.calculateCurrentICDate();
+//             let convertedDate = this.ingameDate;
+//             convertedDate.iDay = moment(ActualIcDate).date();
+//             convertedDate.iMonth = (moment(ActualIcDate).month()) + 1;
+//             convertedDate.iYear = this.calculateActualYear({
+//                 start: convertedDate.iStartYear,
+//                 icStart: convertedDate.icEventStart,
+//                 currentIcDate: ActualIcDate
+//             });
+//             convertedDate.iDayOfWeek = this.calculateNewDayOfWeek({
+//                 startDayOfWeek: convertedDate.iStartDayOfWeek,
+//                 ocStartDate: convertedDate.ocEventStart
+//             });
+//             convertedDate.iDayName = this.convertDayToDayName(convertedDate.iDayOfWeek); // Monday-Sunday
+//             convertedDate.iMonthName = moment().month(convertedDate.iMonth - 1).format('MMMM');
+
+//             this.ingameDate = convertedDate;
+//             return convertedDate;
+//         }
+//         return;
+//     }
+
+//     private static calculateCurrentICDate(): Date {
+//         const hoursPassed = this.calculateHoursSinceStart(this.ingameDate.ocEventStart);
+//         return moment(this.ingameDate.icEventStart).add(hoursPassed, 'hours').toDate();
+//     }
+
+//     private static calculateHoursSinceStart(ocEventStart: Date): number {
+//         const now = moment(new Date());
+//         const start = moment(ocEventStart);
+//         const diff = now.diff(start, 'hours');
+//         return (diff > 0 ? diff : 0);
+//     }
+
+//     //TODO this can be written cleaner.
+//     private static calculateActualYear(params:{ start: number, icStart: Date, currentIcDate: Date}): number {
+//         const icStartYear = moment(params.icStart).year();
+//         const currentYear = moment(params.currentIcDate).year();
+//         const difference = currentYear - icStartYear;
+//         return (difference > 0 ? params.start + difference : params.start);
+//     }
+
+//     private static calculateNewDayOfWeek(params: { startDayOfWeek: number, ocStartDate: Date }): number {
+//         const ocStartDay = moment(params.ocStartDate).date();
+//         const currentDay = moment().date();
+//         let difference = currentDay - ocStartDay;
+//         let dayOfWeek = (difference > 0 ? params.startDayOfWeek + difference : params.startDayOfWeek);
+//         while (dayOfWeek > 7) { // round to the nearest 1-7.
+//             dayOfWeek = (dayOfWeek - 7);
+//         }
+//         return dayOfWeek;
+//     }
+
+//     private static convertDayToDayName(dayOfWeek: number): string {
+//         switch (dayOfWeek) {
+//             case 1: return 'monday'; break;
+//             case 2: return 'tuesday'; break;
+//             case 3: return 'wednesday'; break;
+//             case 4: return 'thursday'; break;
+//             case 5: default: return 'friday'; break;
+//             case 6: return 'saturday'; break;
+//             case 7: return 'sunday'; break;
+//         }
+//     }
+
+// }

--- a/lib/modules/time/time.controller.ts
+++ b/lib/modules/time/time.controller.ts
@@ -10,10 +10,22 @@ import { Server } from "../../bin/server";
 
 dayjs.extend(UTC);
 
-// TODO: dynamic dates
+
+// TODO: dynamic dates.
+
+// Hour placeholder: Force the time to 1200 to prevent timezone issues before dayjs/UTC can fix it.
+const _HOUR_PLACEHOLDER = 12
+
+/**
+ * HEADS UP: Dates in Javascript index their months starting at 0.
+ * This means if you want to set "1 january 2020" you'll need to enter:
+ *      new Date(2020, 0, 1)
+ * 
+ *  instead of the expected 2020, 1, 1.
+ */
 export const eventDateData = {
-    ocEventStartDate: new Date(2023, 5, 9, 12),
-    icEventStartDate: new Date(2023, 6, 17, 12),
+    ocEventStartDate: new Date(2023, 5, 9, _HOUR_PLACEHOLDER),
+    icEventStartDate: new Date(2023, 6, 17, _HOUR_PLACEHOLDER),
 }
 
 /**

--- a/lib/modules/time/time.controller.ts
+++ b/lib/modules/time/time.controller.ts
@@ -1,108 +1,72 @@
-import moment = require('moment');
-import { IcDate } from '../../bin/models/time';
-import { Server } from '../../bin/server';
-const CronJob = require('cron').CronJob;
+const dayjs = require('dayjs');
+const UTC = require('dayjs/plugin/utc');
+const {
+    getLocalizedDayNumber,
+    getDayOfWeekName,
+} = require("./time.helper");
+const { IcDate } = require("../../bin/models/time");
+import { SOCKET_TIME_UPDATE } from "../../shared/constants.sockets";
+import { Server } from "../../bin/server";
 
-export class TimeController {
+dayjs.extend(UTC);
 
-    public static ingameDate: IcDate;
-    //ocEventStart fields: OC Year, OC Month, OC Day, leave 12 as-is.
-    //icEventStart fields: OC Year (Yes, OC), IC Month *minus 1* (so if IC Month is July, then put 6), IC Day, again leave 12 as-is.
-    public static init(): void {
-        if (!this.ingameDate) {
-            this.ingameDate = this.convertToIcDateObject({
-                ocEventStart: new Date(2023, 6, 9, 12), // at 12 o clock for timezone shenanigans.
-                icEventStart: new Date(2023, 6, 17, 12), // It's important that the current IC year is also the OC year.
-                icStartYear: 240,
-                icStartDayOfWeek: 5,
-                icYearAfter: 'NT'
-            });
-        }
-
-        console.log('\x1b[36m[*CRON] TimeSocket cron set to trigger at Midnight.\x1b[0m');
-        this.midnightUpdateCronJob.start();
-    }
-
-    private static midnightUpdateCronJob = new CronJob('0 0 * * *', function () {
-        console.log(`[*CRON] trigger: \x1b[32m{midnightUpdateCronJob}\x1b[0m, ${new Date()}`);
-        Server.socketio().sockets.emit('inGameDateUpdate');
-    });
-
-    private static convertToIcDateObject(input: any): IcDate {
-        let convertedDate = new IcDate();
-            convertedDate.ocEventStart = input.ocEventStart;
-            convertedDate.icEventStart = input.icEventStart;
-            convertedDate.iStartDayOfWeek = input.icStartDayOfWeek;
-            convertedDate.iStartYear = input.icStartYear;
-            convertedDate.iYearAfter = input.icYearAfter;
-        return convertedDate;
-    }
-
-    public static getCurrentDate(): IcDate {
-        if (this.ingameDate) {
-            const ActualIcDate = this.calculateCurrentICDate();
-            let convertedDate = this.ingameDate;
-            convertedDate.iDay = moment(ActualIcDate).date();
-            convertedDate.iMonth = (moment(ActualIcDate).month()) + 1;
-            convertedDate.iYear = this.calculateActualYear({
-                start: convertedDate.iStartYear,
-                icStart: convertedDate.icEventStart,
-                currentIcDate: ActualIcDate
-            });
-            convertedDate.iDayOfWeek = this.calculateNewDayOfWeek({
-                startDayOfWeek: convertedDate.iStartDayOfWeek,
-                ocStartDate: convertedDate.ocEventStart
-            });
-            convertedDate.iDayName = this.convertDayToDayName(convertedDate.iDayOfWeek); // Monday-Sunday
-            convertedDate.iMonthName = moment().month(convertedDate.iMonth - 1).format('MMMM');
-
-            this.ingameDate = convertedDate;
-            return convertedDate;
-        }
-        return;
-    }
-
-    private static calculateCurrentICDate(): Date {
-        const hoursPassed = this.calculateHoursSinceStart(this.ingameDate.ocEventStart);
-        return moment(this.ingameDate.icEventStart).add(hoursPassed, 'hours').toDate();
-    }
-
-    private static calculateHoursSinceStart(ocEventStart: Date): number {
-        const now = moment(new Date());
-        const start = moment(ocEventStart);
-        const diff = now.diff(start, 'hours');
-        return (diff > 0 ? diff : 0);
-    }
-
-    //TODO this can be written cleaner.
-    private static calculateActualYear(params:{ start: number, icStart: Date, currentIcDate: Date}): number {
-        const icStartYear = moment(params.icStart).year();
-        const currentYear = moment(params.currentIcDate).year();
-        const difference = currentYear - icStartYear;
-        return (difference > 0 ? params.start + difference : params.start);
-    }
-
-    private static calculateNewDayOfWeek(params: { startDayOfWeek: number, ocStartDate: Date }): number {
-        const ocStartDay = moment(params.ocStartDate).date();
-        const currentDay = moment().date();
-        let difference = currentDay - ocStartDay;
-        let dayOfWeek = (difference > 0 ? params.startDayOfWeek + difference : params.startDayOfWeek);
-        while (dayOfWeek > 7) { // round to the nearest 1-7.
-            dayOfWeek = (dayOfWeek - 7);
-        }
-        return dayOfWeek;
-    }
-
-    private static convertDayToDayName(dayOfWeek: number): string {
-        switch (dayOfWeek) {
-            case 1: return 'monday'; break;
-            case 2: return 'tuesday'; break;
-            case 3: return 'wednesday'; break;
-            case 4: return 'thursday'; break;
-            case 5: default: return 'friday'; break;
-            case 6: return 'saturday'; break;
-            case 7: return 'sunday'; break;
-        }
-    }
-
+// TODO: dynamic dates
+export const eventDateData = {
+    ocEventStartDate: new Date(2023, 5, 9, 12),
+    icEventStartDate: new Date(2023, 6, 17, 12),
 }
+
+/**
+ * @description Calculate and return the amount of hours between event start and -now-
+ * @param {Date} ocEventStart
+ * @return {Number} amount of time (Ms) passed, minimum of 0
+ */
+export const getTimePassedSinceDate = (startDate) => {
+    let diff = 0;
+
+    if (startDate) {
+        const now = dayjs().utc().hour(23);
+        const start = dayjs(startDate).utc();
+
+        diff = now.diff(start) > 0 ? now.diff(start) : 0;
+    }
+    return diff;
+};
+
+/**
+ *
+ * @param {Date} date
+ * @return {IcDate} converted 'input'
+ */
+export const convertDateObjectToIcDate = (date) => {
+    if (!date) return false;
+
+    const sourceDate = dayjs(date).utc();
+    const iDayOfWeek = getLocalizedDayNumber();
+
+    const input = {
+        iDayOfWeek,
+        iDayName: getDayOfWeekName(iDayOfWeek),
+        iDay: sourceDate.date(),
+        iMonth: sourceDate.month() + 1,
+        iMonthName: sourceDate.format('MMMM').toLowerCase(),
+    };
+
+    return new IcDate(input);
+};
+
+export const getCurrentIcDate = () => {
+    const { ocEventStartDate, icEventStartDate } = eventDateData;
+    const _timePassed = getTimePassedSinceDate(ocEventStartDate);
+    let icDate = convertDateObjectToIcDate(icEventStartDate);
+
+    if (_timePassed > 0) {
+        const modifiedIcDate = dayjs(icEventStartDate)
+            .utc()
+            .add(_timePassed)
+            .toDate();
+        icDate = convertDateObjectToIcDate(modifiedIcDate);
+    }
+
+    return icDate;
+};

--- a/lib/modules/time/time.helper.ts
+++ b/lib/modules/time/time.helper.ts
@@ -1,0 +1,29 @@
+import dayjs from "dayjs";
+import UTC from "dayjs/plugin/utc";
+
+dayjs.extend(UTC);
+
+export const DAY_NAMES = [
+    'monday',
+    'tuesday',
+    'wednesday',
+    'thursday',
+    'friday',
+    'saturday',
+    'sunday'
+];
+
+/**
+ * @optional {Number} dayNumber, (0-6 from Date Objects)
+ * @returns 1-7 daynumbers for Sunday-Last formatting
+ */
+export const getLocalizedDayNumber = (day = dayjs.utc().day()) => day === 0 ? 7 : day;
+
+/**
+ * @param {Number} dayNumber (1 - 7)
+ * @returns string (monday - sunday)
+ */
+export const getDayOfWeekName = (dayNumber?) => {
+    const dayIndex = (dayNumber || getLocalizedDayNumber()) - 1;
+    return DAY_NAMES[dayIndex];
+};

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -11,11 +11,10 @@ const config = require('../_config/config.json');
 
 export class Routes {
 
-    constructor() {
-    }
+    constructor() { }
 
     public static initialize(app: Express): Express {
-        console.log('[RO] The routes are being initialized');
+        console.log('[RO] Setting up (API) routes');
         return Routes.getRoutes(app);
     }
 

--- a/lib/routes/time.routes.ts
+++ b/lib/routes/time.routes.ts
@@ -1,17 +1,13 @@
 import { Router } from 'express';
-import { TimeController } from '../modules/time/time.controller';
-
+import { getCurrentIcDate, eventDateData } from "../modules/time/time.controller";
 export class TimeRoutes {
     public static getRoutes(): Router {
         const router = Router();
 
-        /* start the time controller. */
-        TimeController.init();
-
         /**
          * @description get the current IC date / time. */
         router.route('/').get((req, res) => {
-            res.status(200).send(TimeController.getCurrentDate());
+            res.status(200).send(getCurrentIcDate());
         });
 
         console.log('[RO] ..DateTime Routes added.');

--- a/lib/shared/constants.sockets.ts
+++ b/lib/shared/constants.sockets.ts
@@ -1,0 +1,4 @@
+export const SOCKET_FOB_UPDATE = "fobUpdate"
+export const SOCKET_MISSION_UPDATE = "MissionUpdate"
+export const SOCKET_SECLVL_UPDATE = "securityUpdate"
+export const SOCKET_TIME_UPDATE = "inGameDateUpdate"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,6 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@types/express": "^4.17.1",
-        "@types/ip": "0.0.32",
-        "@types/mongoose": "^5.3.7",
-        "@types/node": "^20.2.5",
-        "@types/socket.io": "^2.1.2",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "cron": "^1.7.1",
@@ -33,6 +28,9 @@
         "typescript": "^5.0.4"
       },
       "devDependencies": {
+        "@types/express": "^4.17.1",
+        "@types/ip": "0.0.32",
+        "@types/node": "^20.2.5",
         "bufferutil": "^4.0.7",
         "ts-node": "^10.9.1",
         "utf-8-validate": "^5.0.10"
@@ -74,11 +72,6 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
-    },
-    "node_modules/@socket.io/component-emitter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -129,14 +122,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/engine.io": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz",
-      "integrity": "sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -162,6 +147,7 @@
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/ip/-/ip-0.0.32.tgz",
       "integrity": "sha512-vCzCQQ4W6PoGMOE1SJY1tGXPBi1Wq2EueEvRWx5qOuz35X7bP0b9MQSN5gBEqKbedsFhsEvgtX6kD6ysut+XHA==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -178,15 +164,6 @@
       "dependencies": {
         "@types/bson": "*",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/mongoose": {
-      "version": "5.11.97",
-      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.11.97.tgz",
-      "integrity": "sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==",
-      "deprecated": "Mongoose publishes its own types, so you do not need to install this package.",
-      "dependencies": {
-        "mongoose": "*"
       }
     },
     "node_modules/@types/node": {
@@ -211,25 +188,6 @@
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/socket.io": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
-      "integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
-      "dependencies": {
-        "@types/engine.io": "*",
-        "@types/node": "*",
-        "@types/socket.io-parser": "*"
-      }
-    },
-    "node_modules/@types/socket.io-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz",
-      "integrity": "sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==",
-      "deprecated": "This is a stub types definition. socket.io-parser provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "socket.io-parser": "*"
       }
     },
     "node_modules/abbrev": {
@@ -1929,34 +1887,6 @@
         "isarray": "2.0.1"
       }
     },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
-      "dependencies": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/socket.io/node_modules/component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -2375,11 +2305,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@socket.io/component-emitter": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
-      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
-    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -2429,14 +2354,6 @@
         "@types/node": "*"
       }
     },
-    "@types/engine.io": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.7.tgz",
-      "integrity": "sha512-qNjVXcrp+1sS8YpRUa714r0pgzOwESdW5UjHL7D/2ZFdBX0BXUXtg1LUrp+ylvqbvMcMWUy73YpRoxPN2VoKAQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/express": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
@@ -2462,6 +2379,7 @@
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/ip/-/ip-0.0.32.tgz",
       "integrity": "sha512-vCzCQQ4W6PoGMOE1SJY1tGXPBi1Wq2EueEvRWx5qOuz35X7bP0b9MQSN5gBEqKbedsFhsEvgtX6kD6ysut+XHA==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -2478,14 +2396,6 @@
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
-      }
-    },
-    "@types/mongoose": {
-      "version": "5.11.97",
-      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.11.97.tgz",
-      "integrity": "sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==",
-      "requires": {
-        "mongoose": "*"
       }
     },
     "@types/node": {
@@ -2510,24 +2420,6 @@
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
-      }
-    },
-    "@types/socket.io": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
-      "integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
-      "requires": {
-        "@types/engine.io": "*",
-        "@types/node": "*",
-        "@types/socket.io-parser": "*"
-      }
-    },
-    "@types/socket.io-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-3.0.0.tgz",
-      "integrity": "sha512-Ry/rbTE6HQNL9eu3LpL1Ocup5VexXu1bSSGlSho/IR5LuRc8YvxwSNJ3JxqTltVJEATLbZkMQETSbxfKNgp4Ew==",
-      "requires": {
-        "socket.io-parser": "*"
       }
     },
     "abbrev": {
@@ -3920,25 +3812,6 @@
             "component-emitter": "~1.3.0",
             "debug": "~3.1.0",
             "isarray": "2.0.1"
-          }
-        }
-      }
-    },
-    "socket.io-parser": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
-      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
-      "requires": {
-        "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,27 @@
 {
   "name": "eos-watchtower",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eos-watchtower",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@types/express": "^4.17.1",
         "@types/ip": "0.0.32",
         "@types/mongoose": "^5.3.7",
+        "@types/node": "^20.2.5",
         "@types/socket.io": "^2.1.2",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "cron": "^1.7.1",
+        "dayjs": "^1.11.7",
         "emoji-strip": "^1.0.1",
         "express": "^4.17.3",
         "express-async-router": "^0.1.15",
-        "moment": "^2.29.4",
         "mongoose": "^5.4.15",
         "nodemon": "^2.0.20",
         "request": "^2.88.0",
@@ -29,17 +30,79 @@
         "striptags": "^3.1.1",
         "tslib": "^1.10.0",
         "typegoose": "^5.9.0",
-        "typescript": "^3.5.3"
+        "typescript": "^5.0.4"
       },
       "devDependencies": {
         "bufferutil": "^4.0.7",
+        "ts-node": "^10.9.1",
         "utf-8-validate": "^5.0.10"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.1",
@@ -127,9 +190,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
-      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A=="
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -186,6 +249,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -217,6 +301,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -516,6 +606,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cron": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/cron/-/cron-1.8.2.tgz",
@@ -534,6 +630,11 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "node_modules/debug": {
       "version": "3.1.0",
@@ -576,6 +677,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -1087,6 +1197,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -1844,7 +1960,7 @@
     "node_modules/socket.io/node_modules/component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA=="
     },
     "node_modules/socket.io/node_modules/debug": {
       "version": "4.1.1",
@@ -1858,12 +1974,12 @@
     "node_modules/socket.io/node_modules/isarray": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+      "integrity": "sha512-c2cu3UxbI+b6kR3fy0nRnAhodsvR9dx7U5+znCOzdj6IfP3upFURTr0Xl5BlQZNKZjEtxrmVyfSdeE3O57smoQ=="
     },
     "node_modules/socket.io/node_modules/socket.io-parser": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.2.tgz",
-      "integrity": "sha512-QFZBaZDNqZXeemwejc7D39jrq2eGK/qZuVDiMPKzZK1hLlNvjGilGt4ckfQZeVX4dGmuPzCytN9ZW1nQlEWjgA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.3.tgz",
+      "integrity": "sha512-1rE4dZN3kCI/E5wixd393hmbqa78vVpkKmnEJhLeWoS/C5hbFYAbcSfnWoaVH43u9ToUVtzKjguxEZq+1XZfCQ==",
       "dependencies": {
         "component-emitter": "1.2.1",
         "debug": "~4.1.0",
@@ -1998,6 +2114,49 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -2047,15 +2206,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/undefsafe": {
@@ -2114,6 +2273,12 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -2167,13 +2332,77 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg=="
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     }
   },
   "dependencies": {
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.1",
@@ -2260,9 +2489,9 @@
       }
     },
     "@types/node": {
-      "version": "16.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.7.1.tgz",
-      "integrity": "sha512-ncRdc45SoYJ2H4eWU9ReDfp3vtFqDYhjOsKlFFUDEn8V1Bgr2RjYal8YT5byfadWIRluhPFU6JiDOl0H6Sl87A=="
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -2315,6 +2544,18 @@
         "negotiator": "0.6.3"
       }
     },
+    "acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -2339,6 +2580,12 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -2583,6 +2830,12 @@
         "vary": "^1"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "cron": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/cron/-/cron-1.8.2.tgz",
@@ -2598,6 +2851,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "debug": {
       "version": "3.1.0",
@@ -2633,6 +2891,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -3074,6 +3338,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -3587,7 +3857,7 @@
         "component-emitter": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+          "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA=="
         },
         "debug": {
           "version": "4.1.1",
@@ -3600,12 +3870,12 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha512-c2cu3UxbI+b6kR3fy0nRnAhodsvR9dx7U5+znCOzdj6IfP3upFURTr0Xl5BlQZNKZjEtxrmVyfSdeE3O57smoQ=="
         },
         "socket.io-parser": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.2.tgz",
-          "integrity": "sha512-QFZBaZDNqZXeemwejc7D39jrq2eGK/qZuVDiMPKzZK1hLlNvjGilGt4ckfQZeVX4dGmuPzCytN9ZW1nQlEWjgA==",
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.3.tgz",
+          "integrity": "sha512-1rE4dZN3kCI/E5wixd393hmbqa78vVpkKmnEJhLeWoS/C5hbFYAbcSfnWoaVH43u9ToUVtzKjguxEZq+1XZfCQ==",
           "requires": {
             "component-emitter": "1.2.1",
             "debug": "~4.1.0",
@@ -3771,6 +4041,27 @@
         "punycode": "^2.1.1"
       }
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -3807,9 +4098,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "undefsafe": {
       "version": "2.0.5",
@@ -3853,6 +4144,12 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3883,6 +4180,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg=="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,14 +36,15 @@
     "@types/express": "^4.17.1",
     "@types/ip": "0.0.32",
     "@types/mongoose": "^5.3.7",
+    "@types/node": "^20.2.5",
     "@types/socket.io": "^2.1.2",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "cron": "^1.7.1",
+    "dayjs": "^1.11.7",
     "emoji-strip": "^1.0.1",
     "express": "^4.17.3",
     "express-async-router": "^0.1.15",
-    "moment": "^2.29.4",
     "mongoose": "^5.4.15",
     "nodemon": "^2.0.20",
     "request": "^2.88.0",
@@ -55,8 +56,8 @@
     "typescript": "^5.0.4"
   },
   "devDependencies": {
-    "ts-node": "^10.9.1",
     "bufferutil": "^4.0.7",
+    "ts-node": "^10.9.1",
     "utf-8-validate": "^5.0.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "test": "jarvis",
     "postinstall": "npm run build-ts && node lib/setup.js",
+    "build": "tsc",
     "build-ts": "tsc",
-    "dev": "ts-node ./lib/index.ts",
+    "dev": "ts-node ./index.ts",
     "start": "npm run serve",
     "serve": "node dist/index.js",
-    "watch-node": "nodemon dist/lib/index.js",
+    "watch-node": "nodemon dist/index.js",
     "watch-ts": "tsc -w",
     "prod": "npm run build-ts && npm run start"
   },
@@ -33,11 +34,6 @@
   },
   "homepage": "https://github.com/goblinbot/eos-watchtower#readme",
   "dependencies": {
-    "@types/express": "^4.17.1",
-    "@types/ip": "0.0.32",
-    "@types/mongoose": "^5.3.7",
-    "@types/node": "^20.2.5",
-    "@types/socket.io": "^2.1.2",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "cron": "^1.7.1",
@@ -56,6 +52,9 @@
     "typescript": "^5.0.4"
   },
   "devDependencies": {
+    "@types/express": "^4.17.1",
+    "@types/ip": "0.0.32",
+    "@types/node": "^20.2.5",
     "bufferutil": "^4.0.7",
     "ts-node": "^10.9.1",
     "utf-8-validate": "^5.0.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eos-watchtower",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Eos LARP Rest API",
   "main": "index.js",
   "scripts": {
@@ -52,6 +52,9 @@
     "striptags": "^3.1.1",
     "tslib": "^1.10.0",
     "typegoose": "^5.9.0",
-    "typescript": "^3.5.3"
+    "typescript": "^5.0.4"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,8 @@
     },
     "include": [
         "lib/**/*.ts",
-        "lib/**/*.json"
+        "lib/**/*.json",
+        "index.ts"
     ],
     "exclude": [
         "node_modules"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
         "resolveJsonModule": true,
         "experimentalDecorators": true,
         "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
         "pretty": true,
         "sourceMap": true,
         "target": "es6",


### PR DESCRIPTION
- Fix Mongo based updates by replacing the update with findOneAndUpdate methods
- Replace Time/Date code with cleaner, non-moment using variant made for earlier attempts to remove TS altogether.
- Replaced some outdated dependancies
- Installed dayJS
- Fixed OC event date (July -> June)
- Moved socket strings to shared CONST file